### PR TITLE
Immediately update default gas used when src/dest token changed

### DIFF
--- a/src/components/swap/Swap.js
+++ b/src/components/swap/Swap.js
@@ -56,6 +56,8 @@ function mapDispatchToProps(dispatch) {
 
 class Swap extends Component {
   componentDidMount = () => {
+    this.props.setSourceToken(this.props.sourceToken);
+    this.props.setDestToken(this.props.destToken);
     this.props.fetchTokenPairRate();
   };
 
@@ -78,7 +80,7 @@ class Swap extends Component {
 
     this.props.resetAllTxStatus();
     this.props.setIsConfirmModalActive((true));
-    
+
     // set focus to input password
     if (this.swapView && this.swapView.passwdInput) {
       setTimeout(() => {
@@ -119,7 +121,7 @@ class Swap extends Component {
         setDestToken={this.props.setDestToken}
         openModal={this.openModal}
         closeModal={this.closeModal}
-        onRef={ref => (this.swapView = ref)} 
+        onRef={ref => (this.swapView = ref)}
       />
     )
   }

--- a/src/components/transfer/Transfer.js
+++ b/src/components/transfer/Transfer.js
@@ -44,6 +44,10 @@ function mapDispatchToProps(dispatch) {
 }
 
 class Transfer extends Component {
+  componentDidMount = () => {
+    this.props.setSourceToken(this.props.sourceToken);
+  }
+
   handleSetToAddress = (event) => {
     const toAddress = (event.target.value).toLowerCase();
 

--- a/src/sagas/swapSaga.js
+++ b/src/sagas/swapSaga.js
@@ -14,7 +14,13 @@ import {
 import appConfig from "../config/app";
 import envConfig from "../config/env";
 import { TOMO } from "../config/tokens";
-import { getTxObject, fetchTransactionReceipt, fetchTxEstimatedGasUsed, setTxStatusBasedOnWalletType } from "./transactionSaga";
+import {
+  getTxObject,
+  fetchTransactionReceipt,
+  fetchTxEstimatedGasUsed,
+  fetchTxEstimatedGasUsedTokensChanged,
+  setTxStatusBasedOnWalletType
+} from "./transactionSaga";
 
 const getSwapState = state => state.swap;
 const getAccountState = state => state.account;
@@ -163,7 +169,7 @@ function *validateValidInput(swap, account) {
     sourceAmountInTOMO = sourceAmount * sourceToken.sellRate;
   }
 
-  if (swap.tokenPairRate === 0) {
+  if (sourceAmountString !== '' && swap.tokenPairRate === 0) {
     yield put(swapActions.setError(`Your source amount exceeds our max capacity, please reduce your amount`));
     return false;
   }
@@ -258,6 +264,12 @@ export default function* swapWatcher() {
       tokenActions.tokenActionTypes.SET_TOKENS
     ], validateInputAmountMightChange
   );
+  yield takeLatest(
+    [
+      swapActions.swapActionTypes.SET_SOURCE_TOKEN,
+      swapActions.swapActionTypes.SET_DEST_TOKEN,
+    ], fetchTxEstimatedGasUsedTokensChanged
+  )
   yield takeLatest(swapActions.swapActionTypes.SWAP_TOKEN, swapToken);
   yield takeLatest(swapActions.swapActionTypes.APPROVE, approve);
 }

--- a/src/sagas/transactionSaga.js
+++ b/src/sagas/transactionSaga.js
@@ -50,6 +50,24 @@ export function *setTxStatusBasedOnWalletType(walletType, status) {
   }
 }
 
+// To update default est gas used when src/dest token changed
+export function *fetchTxEstimatedGasUsedTokensChanged() {
+  let defaultGasUsed;
+  const exchangeMode = yield select(getExchangeMode);
+  if (exchangeMode === appConfig.EXCHANGE_SWAP_MODE) {
+    const swap = yield select(getSwapState);
+    const isSwapTOMO = swap.sourceToken.address === TOMO.address || swap.destToken.address === TOMO.address;
+    defaultGasUsed = isSwapTOMO ? appConfig.DEFAULT_SWAP_TOMO_GAS_LIMIT : appConfig.DEFAULT_SWAP_TOKEN_GAS_LIMIT;
+  } else {
+    const transfer = yield select(getTransferState);
+    const isTransferTOMO = transfer.sourceToken.address === TOMO.address;
+    defaultGasUsed = isTransferTOMO ? appConfig.DEFAULT_TRANSFER_TOMO_GAS_LIMIT : appConfig.DEFAULT_TRANSFER_TOKEN_GAS_LIMIT;
+  }
+  const txFee = defaultGasUsed * appConfig.DEFAULT_GAS_PRICE / Math.pow(10.0, TOMO.decimals);
+  yield call(setTxFeeAndGasLimit, txFee, defaultGasUsed, exchangeMode);
+  yield call(fetchTxEstimatedGasUsed);
+}
+
 export function *fetchTxEstimatedGasUsed() {
   const isAccountImported = yield select(getAccountAddress);
 

--- a/src/sagas/transferSaga.js
+++ b/src/sagas/transferSaga.js
@@ -9,6 +9,7 @@ import { TOMO } from "../config/tokens";
 import {
   fetchTransactionReceipt,
   fetchTxEstimatedGasUsed,
+  fetchTxEstimatedGasUsedTokensChanged,
   getTxObject,
   setTxStatusBasedOnWalletType
 } from "./transactionSaga";
@@ -130,7 +131,8 @@ function *setError(errorMessage) {
 
 export default function* transferWatcher() {
   yield takeLatest(transferActions.transferActionTypes.TRANSFER, transfer);
-  yield takeLatest([transferActions.transferActionTypes.SET_SOURCE_AMOUNT, transferActions.transferActionTypes.SET_SOURCE_TOKEN], fetchTxEstimatedGasUsed);
+  yield takeLatest(transferActions.transferActionTypes.SET_SOURCE_TOKEN, fetchTxEstimatedGasUsedTokensChanged);
+  yield takeLatest(transferActions.transferActionTypes.SET_SOURCE_AMOUNT, fetchTxEstimatedGasUsed);
   yield takeLatest(
     [
       transferActions.transferActionTypes.SET_SOURCE_AMOUNT,


### PR DESCRIPTION
Currently when src/dest token changed, the estimate gas will need to wait for response from network to update while it should immediately update to default gas used
This will help update est gas used when src/dest token changed
Also call set src/dest token event for swap/transfer when component did mount.