### PR TITLE
Reset token balances when removed account, check balance not loaded with undefine value

### DIFF
--- a/src/components/commons/InputGroup.js
+++ b/src/components/commons/InputGroup.js
@@ -40,8 +40,10 @@ export default class InputGroup extends Component {
       const defaultGasLimit = this.props.isSwap ? appConfig.DEFAULT_SWAP_TOMO_GAS_LIMIT : appConfig.DEFAULT_TRANSFER_TOMO_GAS_LIMIT;
       deductAmountForTxFee = defaultGasLimit * appConfig.DEFAULT_GAS_PRICE / Math.pow(10.0, TOMO.decimals);
     }
+    var srcAmount = Math.min(sourceAmountByPercentage, srcTokenBalance - deductAmountForTxFee);
+    if (srcAmount <= 1e-9) { srcAmount = 0; }
 
-    this.props.setSourceAmount(Math.min(sourceAmountByPercentage, srcTokenBalance - deductAmountForTxFee));
+    this.props.setSourceAmount(srcAmount);
     this.closeBalanceBox();
   };
 

--- a/src/components/swap/Swap.js
+++ b/src/components/swap/Swap.js
@@ -84,7 +84,7 @@ class Swap extends Component {
       return;
     }
 
-    if (!this.props.sourceToken.balance) {
+    if (this.props.sourceToken.balance === undefined) {
       this.props.setError("Please wait for your balance to be loaded");
       return;
     }

--- a/src/components/transfer/Transfer.js
+++ b/src/components/transfer/Transfer.js
@@ -74,7 +74,7 @@ class Transfer extends Component {
   };
 
   openConfirmModal = () => {
-    if (!this.props.sourceAmount) {
+    if (this.props.sourceAmount === '') {
       this.props.setError("Source amount is required to make a transfer");
       return;
     }
@@ -94,7 +94,7 @@ class Transfer extends Component {
       return;
     }
 
-    if (!this.props.sourceToken.balance) {
+    if (this.props.sourceToken.balance === undefined) {
       this.props.setError("Please wait for your balance to be loaded");
       return;
     }

--- a/src/sagas/accountSaga.js
+++ b/src/sagas/accountSaga.js
@@ -24,6 +24,17 @@ function *fetchBalancesChannel() {
   }
 }
 
+function *resetTokenBalancesIfNeeded() {
+  let address = yield select(getAccountAddress);
+  if (!address) {
+    const tokens = yield select(getTokens);
+    tokens.forEach((token, index) => {
+      token.balance = undefined;
+    });
+    yield put(setTokens(tokens));
+  }
+}
+
 function *fetchBalance(address, isFirstLoading = false) {
   yield put(setBalanceLoading(isFirstLoading));
 
@@ -41,5 +52,6 @@ function *fetchBalance(address, isFirstLoading = false) {
 
 export default function* accountWatcher() {
   yield takeLatest(accountActions.accountActionTypes.SET_WALLET, fetchTxEstimatedGasUsed);
+  yield takeLatest(accountActions.accountActionTypes.SET_WALLET, resetTokenBalancesIfNeeded);
   yield takeLatest(accountActions.accountActionTypes.FETCH_BALANCES, fetchBalancesChannel);
 }


### PR DESCRIPTION
Some issues: 
1. When removed account, balance of each token is not removed (click to select token to see balance)
2. When token balance is too small, click to % amount will put a very small value to input box
3. To check if balance is loaded, should check balance with undefined instead of using !balance (!0 is false so if balance is 0 it will false as well)